### PR TITLE
change tide_config to accept URL as an env variable

### DIFF
--- a/src/tidecli/tide_config.py
+++ b/src/tidecli/tide_config.py
@@ -2,7 +2,11 @@ import os
 
 # Configuration for the TIM /oauth
 CLIENT_ID = "oauth2_tide"
-TIM_URL = "http://localhost" if os.getenv("DEV") else "https://tim.jyu.fi"
+# Use DEV for localhost development address
+# For the tim url, use default https://tim.jyu.fi if the user does not supply custom url
+TIM_URL = (
+    "http://localhost" if os.getenv("DEV") else os.getenv("URL", "https://tim.jyu.fi")
+)
 AUTH_ENDPOINT = "/oauth/authorize"
 TOKEN_ENDPOINT = "/oauth/token"
 PORT = 8083

--- a/src/tidecli/tide_config.py
+++ b/src/tidecli/tide_config.py
@@ -5,7 +5,7 @@ CLIENT_ID = "oauth2_tide"
 # Use DEV for localhost development address
 # For the tim url, use default https://tim.jyu.fi if the user does not supply custom url
 TIM_URL = (
-    "http://localhost" if os.getenv("DEV") else os.getenv("URL", "https://tim.jyu.fi")
+    "http://localhost" if os.getenv("DEV") else os.getenv("TIM_URL", "https://tim.jyu.fi")
 )
 AUTH_ENDPOINT = "/oauth/authorize"
 TOKEN_ENDPOINT = "/oauth/token"


### PR DESCRIPTION
This pull request changes the TIM_URL variable in the tide_config.py file to accept a new passed environmental variable URL. The purpose of this change is to allow any TIDE-Plugin to set its preferred url to be used with the TIDE-CLI. 

The default address still remains tim.jyu.fi and the DEV environmental variable is still functioning as before.