### PR TITLE
Ttv 105 non-editable-only flag to task reset function

### DIFF
--- a/src/tidecli/main.py
+++ b/src/tidecli/main.py
@@ -206,7 +206,7 @@ def create(
 
 @task.command()
 @click.option(
-    "--only-noneditable-sections",
+    "--non-editable-only",
     "-n",
     "noneditable_sections",
     is_flag=True,
@@ -215,9 +215,10 @@ def create(
 @click.argument("file_path_string", type=str, required=True)
 def reset(file_path_string: str, noneditable_sections: bool) -> None:
     """
-    Enter the path of the task file to reset.
+    Reset the contents of a task file.
 
-    param file_path_string: Path to the task file in the local file system.
+    :param file_path_string: Path to the task file in the local file system.
+    :param noneditable_sections: If set, only reset non-editable sections.
     """
     if not is_logged_in():
         return

--- a/src/tidecli/main.py
+++ b/src/tidecli/main.py
@@ -208,17 +208,17 @@ def create(
 @click.option(
     "--non-editable-only",
     "-n",
-    "noneditable_sections",
+    "keep_user_code",
     is_flag=True,
     default=False,
 )
 @click.argument("file_path_string", type=str, required=True)
-def reset(file_path_string: str, noneditable_sections: bool) -> None:
+def reset(file_path_string: str, keep_user_code: bool) -> None:
     """
     Reset the contents of a task file.
 
     :param file_path_string: Path to the task file in the local file system.
-    :param noneditable_sections: If set, only reset non-editable sections.
+    :param keep_user_code: If set, resets only the non-editable parts of the task file, preserving user code.
     """
     if not is_logged_in():
         return
@@ -247,7 +247,7 @@ def reset(file_path_string: str, noneditable_sections: bool) -> None:
     if task_file_contents is None:
         raise click.ClickException("File is not part of this task")
 
-    if noneditable_sections:
+    if keep_user_code:
         combined_contents = answer_with_original_noneditable_sections(
             file_contents, task_file_contents
         )

--- a/src/tidecli/main.py
+++ b/src/tidecli/main.py
@@ -208,17 +208,17 @@ def create(
 @click.option(
     "--non-editable-only",
     "-n",
-    "keep_user_code",
+    "non_editable_only",
     is_flag=True,
     default=False,
 )
 @click.argument("file_path_string", type=str, required=True)
-def reset(file_path_string: str, keep_user_code: bool) -> None:
+def reset(file_path_string: str, non_editable_only: bool) -> None:
     """
     Reset the contents of a task file.
 
     :param file_path_string: Path to the task file in the local file system.
-    :param keep_user_code: If set, resets only the non-editable parts of the task file, preserving user code.
+    :param non_editable_only: If set, resets only the non-editable parts of the task file, preserving user code.
     """
     if not is_logged_in():
         return
@@ -247,7 +247,7 @@ def reset(file_path_string: str, keep_user_code: bool) -> None:
     if task_file_contents is None:
         raise click.ClickException("File is not part of this task")
 
-    if keep_user_code:
+    if non_editable_only:
         combined_contents = answer_with_original_noneditable_sections(
             file_contents, task_file_contents
         )

--- a/src/tidecli/main.py
+++ b/src/tidecli/main.py
@@ -205,14 +205,14 @@ def create(
 
 
 @task.command()
+@click.option("--only-noneditable-sections", "-n", "noneditable_sections", is_flag=True, default=False)
 @click.argument("file_path_string", type=str, required=True)
-def reset(file_path_string: str) -> None:
+def reset(file_path_string: str, noneditable_sections: bool) -> None:
     """
     Enter the path of the task file to reset.
 
     param file_path_string: Path to the task file in the local file system.
     """
-    # TODO: currently resets only non-gap parts, should reset all parts or be renamed
     if not is_logged_in():
         return
 
@@ -242,11 +242,13 @@ def reset(file_path_string: str) -> None:
 
     file_path.write_text(task_file_contents)
 
-    combined_contents = answer_with_original_noneditable_sections(
-        file_contents, task_file_contents
-    )
-
-    file_path.write_text(combined_contents)
+    if noneditable_sections:
+        combined_contents = answer_with_original_noneditable_sections(
+            file_contents, task_file_contents
+        )
+        file_path.write_text(combined_contents)  # Kirjoitetaan yhdistetyt sisällöt
+    else:
+        file_path.write_text(task_file_contents)  # Kirjoitetaan vain tehtävän sisältö
 
 
 @tim_ide.command()

--- a/src/tidecli/main.py
+++ b/src/tidecli/main.py
@@ -205,7 +205,13 @@ def create(
 
 
 @task.command()
-@click.option("--only-noneditable-sections", "-n", "noneditable_sections", is_flag=True, default=False)
+@click.option(
+    "--only-noneditable-sections",
+    "-n",
+    "noneditable_sections",
+    is_flag=True,
+    default=False,
+)
 @click.argument("file_path_string", type=str, required=True)
 def reset(file_path_string: str, noneditable_sections: bool) -> None:
     """
@@ -240,15 +246,13 @@ def reset(file_path_string: str, noneditable_sections: bool) -> None:
     if task_file_contents is None:
         raise click.ClickException("File is not part of this task")
 
-    file_path.write_text(task_file_contents)
-
     if noneditable_sections:
         combined_contents = answer_with_original_noneditable_sections(
             file_contents, task_file_contents
         )
-        file_path.write_text(combined_contents)  # Kirjoitetaan yhdistetyt sisällöt
+        file_path.write_text(combined_contents)
     else:
-        file_path.write_text(task_file_contents)  # Kirjoitetaan vain tehtävän sisältö
+        file_path.write_text(task_file_contents)
 
 
 @tim_ide.command()


### PR DESCRIPTION
Added an option to the task reset function to choose whether to reset the entire task file or only the non-editable sections.  

### Changes  
- By default (without the `-n` flag), the function resets the task file to its original state, as it was when downloaded to the local filesystem.  
- When using the `-n` flag:  
  - The function attempts to locate the lines `"Write your code below this line"` and `"Write your code above this line"`.  
  - If found, it resets only the content outside the area defined by these markers, preserving user edits.  
  - If these lines are not found, the file remains unchanged.  
